### PR TITLE
Fixes issue where customer sessions are overwritten by static resource requests

### DIFF
--- a/src/Lib/Bugsnag.php
+++ b/src/Lib/Bugsnag.php
@@ -43,10 +43,7 @@ class Bugsnag
             }
 
             $bugsnag = $this->clientFactory->make($this->config->getApiKey(), $this->config->getEndpoint());
-            $bugsnag->registerCallback([$this->customerCallback, 'report'])
-                ->registerCallback([$this->magentoCallback, 'report'])
-                ->setReleaseStage($this->config->getReleaseStage())
-                ->startSession();
+            $bugsnag->setReleaseStage($this->config->getReleaseStage())->startSession();
 
             // Custom event to allow developers to extend default bugsnag configuration
             $this->eventManager->dispatch('bugsnag_init', ['client' => $bugsnag]);
@@ -54,5 +51,13 @@ class Bugsnag
         }
 
         return $this->client;
+    }
+
+    public function registerCallbacks($isHttpRequest = false)
+    {
+        $this->client->registerCallback([$this->magentoCallback, 'report']);
+        if ($isHttpRequest) {
+            $this->client->registerCallback([$this->customerCallback, 'report']);
+        }
     }
 }

--- a/src/Plugins/ConfigureBugsnagNotifier.php
+++ b/src/Plugins/ConfigureBugsnagNotifier.php
@@ -35,6 +35,7 @@ class ConfigureBugsnagNotifier
             return;
         }
         $client = $this->bugsnag->init();
+        $this->bugsnag->registerCallbacks($instance instanceof Http);
         $client->setMetaData([
             'app' => [
                 'request_type' => $this->getRequestType($instance),


### PR DESCRIPTION
The static resource requests don't have sessions, so the customer callback ended up starting a new session if there was an exception (such as a 404 for missing resources). This would then will log out any customers next time they visited another page.

Resolved by breaking the callbacks out into a new method which is instantiated inside the `beforeLaunch` plugin only when AppInterface is an instance of `\Magento\Framework\App\Http` to ensure it's a request that will have an existing session!