### PR TITLE
Removes dependency on \Magento\Store\Model\Store

### DIFF
--- a/src/Lib/Callbacks/Magento.php
+++ b/src/Lib/Callbacks/Magento.php
@@ -6,23 +6,25 @@ use Bugsnag\Report;
 use Magento\Framework\App\ProductMetadataInterface;
 use Magento\Framework\App\State;
 use Magento\Framework\Exception\LocalizedException;
-use Magento\Framework\Exception\NoSuchEntityException;
-use Magento\Store\Model\StoreManagerInterface;
+use Magento\Store\Model\ScopeInterface;
 
 class Magento implements CallbackInterface
 {
     private $metadata;
     private $appState;
-    private $storeManager;
+    private $runMode;
+    private $scopeCode;
 
     public function __construct(
         ProductMetadataInterface $metadata,
         State $appState,
-        StoreManagerInterface $storeManager
+        $runMode = ScopeInterface::SCOPE_STORE,
+        $scopeCode = null
     ) {
         $this->metadata = $metadata;
         $this->appState = $appState;
-        $this->storeManager = $storeManager;
+        $this->runMode = $runMode;
+        $this->scopeCode = $scopeCode;
     }
 
     public function report(Report $report)
@@ -32,7 +34,8 @@ class Magento implements CallbackInterface
                 'version' => $this->metadata->getVersion(),
                 'edition' => $this->metadata->getEdition(),
                 'area_code' => $this->getAreaCode(),
-                'store_code' => $this->getStoreCode(),
+                'run_mode' => $this->runMode,
+                'store_code' => $this->scopeCode,
             ],
         ]);
     }
@@ -44,15 +47,6 @@ class Magento implements CallbackInterface
         } catch (LocalizedException $exception) {
             // The application didn't make it far enough to set the area code!
             return 'not set';
-        }
-    }
-
-    private function getStoreCode(): string
-    {
-        try {
-            return $this->storeManager->getStore()->getCode();
-        } catch (NoSuchEntityException $exception) {
-            return 'no such store found';
         }
     }
 }

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -3,4 +3,10 @@
     <type name="Magento\Framework\AppInterface">
         <plugin name="bugsnag_setup" type="Ashsmith\Bugsnag\Plugins\ConfigureBugsnagNotifier" />
     </type>
+    <type name="Ashsmith\Bugsnag\Lib\Callbacks\Magento">
+        <arguments>
+            <argument name="runMode" xsi:type="init_parameter">Magento\Store\Model\StoreManager::PARAM_RUN_TYPE</argument>
+            <argument name="scopeCode" xsi:type="init_parameter">Magento\Store\Model\StoreManager::PARAM_RUN_CODE</argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
The Store model requires the session, which require the app state to be defined.

When an error or exception occurs before the app state has been initialised this causes an error that crashes Magento.

The workaround is to use the runMode and scopeCode parameters, which originate from $_SERVER which is where the store code is set.